### PR TITLE
Performance fix and enhancement for SAST-Create-Report

### DIFF
--- a/cx-sast-shell-tools/SAST-Create-Report.bat
+++ b/cx-sast-shell-tools/SAST-Create-Report.bat
@@ -1,0 +1,3 @@
+@echo off;
+REM Add parameter -report_type '%2' if any report type other than PDF is required.  Other options are CSV, RTF or XML.
+powershell.exe -ExecutionPolicy Bypass "& '.\SAST-Create-Report.ps1' -sast_url '%1'


### PR DESCRIPTION
Moved credentials to Credentials Manager
Moved the teams to a file input: ReportTeams.txt
Performance fix to request each report one at at time so as not to overload the manager with requests. Created a suggested batch file to run the script in default PDF output mode, that takes the server URL as a parameter.